### PR TITLE
Upgrading auditor chart to 1.0.8

### DIFF
--- a/helm/auditor.yaml
+++ b/helm/auditor.yaml
@@ -1,7 +1,7 @@
 name: aws-key-auditor-helm
 namespace: buffer
 chart: "buffercharts/buffer-cronjob"
-chartVersion: "1.0.6"
+chartVersion: "1.0.8"
 cdEnabled: false
 cdBranchEnabled: false
 dockerfile: Dockerfile


### PR DESCRIPTION
Upgraded the chart `buffer-cronjob` used by `auditor` from version 1.0.6 to 1.0.8