### PR TITLE
Use v14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:14-alpine
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
Simply update to v14 as part of the [Node v10 EOL](https://paper.dropbox.com/doc/Node-v10-EOL-project--BE~Kn61BuDC3C4s4F7FHi5WJAg-tExkWyv45ZCtAr0Vm9U4e) work.

The service isn't running currently doe to some credentials issues, have pinged Steven in the doc above to check up on that separately. Service does run successfully locally with v14.